### PR TITLE
do not translate empty string

### DIFF
--- a/src/include/sssd-parameters.rb
+++ b/src/include/sssd-parameters.rb
@@ -966,7 +966,7 @@ module Yast
                         "" => {
                             "type" => "string",
                             "def"  => "",
-                            "desc" => _("")
+                            "desc" => ""
                         },
 #                        "" => {
 #                            "type" => "string",


### PR DESCRIPTION
it has a special meaning and gettext prints a warning:

```
Warning: The empty "" msgid is reserved by gettext. So gettext("")
doesn't returns empty string but the header entry in po file.
```
