### PR TITLE
Add help message for 'services' config parameter, tailored to the capability of this Yast module.

### DIFF
--- a/src/include/sssd-parameters.rb
+++ b/src/include/sssd-parameters.rb
@@ -18,7 +18,8 @@ module Yast
                         },
                         "services" => {
                             "type" => "string",
-                            "desc" => _("Comma separated list of services that are started when sssd itself starts.")
+                            "desc" => _("Comma separated list of services that are started when sssd itself starts.") +
+                                      _("\nSupported services: nss, pam, sudo, autofs, ssh")
                         },
                         "reconnection_retries" => {
                             "type" => "int",


### PR DESCRIPTION
Note that the man page of sssd.conf mentions PAC as one of the supported services, however the Yast module does not support PAC, and OpenSUSE does not have PAC plugin packaged.