### PR TITLE
fix a typo in parameter name "ipa_server"

### DIFF
--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Apr 21 07:38:07 UTC 2015 - hguo@suse.com
+
+- Fix a typo in parameter name "ipa_server".
+
+-------------------------------------------------------------------
 Mon Apr 20 11:30:36 UTC 2015 - hguo@suse.com
 
 - Fix the handling of boolean type parameters when invoked by autoyast.

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        3.2.1
+Version:        3.2.2
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0

--- a/src/lib/yauthclient/params.rb
+++ b/src/lib/yauthclient/params.rb
@@ -1194,7 +1194,7 @@ module YAuthClient
                             "type" => "string",
                             "desc" => _("Specifies the name of the IPA domain.")
                         },
-                        "ipa_server," => {
+                        "ipa_server" => {
                             "type" => "string",
                             "desc" => _("The comma-separated list of IP addresses or hostnames of the IPA servers to which SSSD should connect in the order of preference.")
                         },


### PR DESCRIPTION
fix a typo in parameter name "ipa_server"