### PR TITLE
Fix crash when selecting auth provider 'none'

### DIFF
--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 24 11:58:16 UTC 2015 - igonzalezsosa@suse.com
+
+- Fix crash when selecting 'none' as authentication provider
+  (bsc#955883)
+- 3.1.23.2
+
+-------------------------------------------------------------------
 Fri Oct  2 13:15:11 UTC 2015 - mvidner@suse.com
 
 - Fixed "Relax-NG parser error : Some defines for timeout needs the

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -18,7 +18,7 @@
 
 
 Name:           yast2-auth-client
-Version:        3.1.23.1
+Version:        3.1.23.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/dialogs.rb
+++ b/src/include/dialogs.rb
@@ -266,7 +266,7 @@ module Yast
         end
         if AuthClient.auth["sssd_conf"][section].has_key?("auth_provider")
            _auth_provider = AuthClient.auth["sssd_conf"][section]["auth_provider"]
-           @params[_auth_provider].each_key { |k| 
+           @params.fetch(_auth_provider, {}).each_key { |k| 
              if @params[_auth_provider][k].has_key?("req") && ! _params.include?(k)
                AuthClient.auth["sssd_conf"][section][k] = GetParameterDefault(k)
                _params.push(k)


### PR DESCRIPTION
This PR fix [bsc#955883](https://bugzilla.suse.com/show_bug.cgi?id=955883). The dialogs have been rewritten on `SLE 12 SP1` so this patch only make sense for `SLE 12`.