### PR TITLE
bnc#991855 - Add missing search_base related attributes to auth-client ldap domain

### DIFF
--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug  3 09:45:49 UTC 2016 - ralf.habacker@freenet.de
+
+- Add missing search_base related attributes
+  to auth-client ldap domain. (bnc#991855)
+- 3.1.22
+
+-------------------------------------------------------------------
 Tue Sep 16 12:25:58 UTC 2014 - varkoly@suse.com
 
 - Fix frame description.

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        3.1.21
+Version:        3.1.22
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/sssd-parameters.rb
+++ b/src/include/sssd-parameters.rb
@@ -427,7 +427,7 @@ module Yast
                         },
                         "ldap_sudo_search_base" => {
                             "type" => "string",
-                            "def"  => "",
+                            "def"  => "the value of ldap_search_base",
                             "rule" => /(^[\s]*[\w]+=[\w]+|^$)/,
                             "desc" => _("The default base DN to use for performing LDAP sudo rules.")
                         }
@@ -968,6 +968,30 @@ module Yast
                             "type" => "boolean",
                             "def"  => "false",
                             "desc" => _("Allows to retain local users as members of an LDAP group for servers that use the RFC2307 schema.")
+                        },
+                        "ldap_autofs_search_base" => {
+                            "type" => "string",
+                            "def"  => "the value of ldap_search_base",
+                            "rule" => /(^[\s]*[\w]+=[\w]+|^$)/,
+                            "desc" => _("An optional base DN, search scope and LDAP filter to restrict LDAP searches for this attribute type.")
+                        },
+                        "ldap_group_search_base" => {
+                            "type" => "string",
+                            "def"  => "the value of ldap_search_base",
+                            "rule" => /(^[\s]*[\w]+=[\w]+|^$)/,
+                            "desc" => _("An optional base DN, search scope and LDAP filter to restrict LDAP searches for this attribute type.")
+                        },
+                        "ldap_netgroup_search_base" => {
+                            "type" => "string",
+                            "def"  => "the value of ldap_search_base",
+                            "rule" => /(^[\s]*[\w]+=[\w]+|^$)/,
+                            "desc" => _("An optional base DN, search scope and LDAP filter to restrict LDAP searches for this attribute type.")
+                        },
+                        "ldap_user_search_base" => {
+                            "type" => "string",
+                            "def"  => "the value of ldap_search_base",
+                            "rule" => /(^[\s]*[\w]+=[\w]+|^$)/,
+                            "desc" => _("An optional base DN, search scope and LDAP filter to restrict LDAP searches for this attribute type.")
                         },
                         "" => {
                             "type" => "string",


### PR DESCRIPTION
for opensuse 13.2, for related bug see https://bugzilla.novell.com/show_bug.cgi?id=991855