### PR TITLE
Add authconf textdomain

### DIFF
--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Oct  3 12:11:27 UTC 2016 - igonzalezsosa@suse.com
+
+- Add missing textdomain declaration for localization (bsc#988374)
+- Bump version to 3.3.12
+
+-------------------------------------------------------------------
 Tue Sep  6 12:32:42 UTC 2016 - hguo@suse.com
 
 - Fix an issue with UI layout after leaving a domain (bsc#997380).

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        3.3.11
+Version:        3.3.12
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0

--- a/src/lib/auth/authconf.rb
+++ b/src/lib/auth/authconf.rb
@@ -72,6 +72,8 @@ module Auth
         end
 
         def initialize
+            textdomain "auth-client"
+
             Yast.import "Nsswitch"
             Yast.import "Pam"
             Yast.import "Service"


### PR DESCRIPTION
Add missing textdomain declaration as stated [in this comment](https://bugzilla.suse.com/show_bug.cgi?id=988374#c6).