### PR TITLE
Use Docker at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
-language: cpp
-compiler:
-    - gcc
-before_install:
-    # disable rvm, use system Ruby
-    - rvm reset
-    - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "rake yast2-devtools yast2-testsuite yast2 yast2-pam yast2-network" -g "rspec:3.3.0 yast-rake gettext"
-script:
-    - rake check:syntax
-    - rake check:pot
-    - rake check:license
-    - rake test:unit
+sudo: required
+language: bash
+services:
+  - docker
 
+before_install:
+  - docker build -t yast-auth-client-image .
+script:
+  # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
+  # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-auth-client-image yast-travis-ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM yastdevel/ruby
+COPY . /usr/src/app
+

--- a/test/authconf_test.rb
+++ b/test/authconf_test.rb
@@ -25,17 +25,14 @@ require 'yast/rspec'
 require 'pp'
 require 'auth/authconf'
 
-include Yast
-include Auth
-
-describe AuthConf do
+describe Auth::AuthConf do
     before(:all) do
         change_scr_root(File.expand_path('../authconf_chroot', __FILE__))
     end
     after(:all) do
         reset_scr_root
     end
-    authconf = AuthConfInst
+    authconf = Auth::AuthConfInst
 
     describe 'SSSD' do
         it 'Read, lint, and export SSSD configuration' do
@@ -398,7 +395,7 @@ module i/j/k.l:RESIDUAL
 
     describe 'Network facts' do
         it 'Read host name and network facts' do
-            facts = AuthConf.get_net_facts
+            facts = Auth::AuthConf.get_net_facts
             # No value can be nil
             expect(facts.any?{ |_k, v| v.nil? }).to eq(false)
             # There has to be at least one value that is present

--- a/test/sssd_uidata_test.rb
+++ b/test/sssd_uidata_test.rb
@@ -28,7 +28,7 @@ describe SSSD::UIData do
             'extra_svcs'=>[],
             'enabled'=>false}
         # AuthConfInst is the backbone of uidata
-        AuthConf::AuthConfInst.sssd_import(preload_conf)
+        Auth::AuthConfInst.sssd_import(preload_conf)
 
         it "Retrieve global options from section sssd that does not yet have parameters " do
             # Section configuration is a list of ["name", "value", "desc"]


### PR DESCRIPTION
## Fixed Tests

The tests were broken - one of the tests included some namespaces used in the other tests into the global namespace, the result was order dependent test results.

This test run failed:

```bash
rspec --color --format doc 'test/sssd_params_test.rb' \
  'test/sssd_uidata_test.rb' 'test/authconf_test.rb'
```

While this one passed:
```bash
rspec --color --format doc 'test/authconf_test.rb' \
  'test/sssd_params_test.rb' 'test/sssd_uidata_test.rb' 
```

The order in `rake test:unit` is undefined so in some cases it passed in other cases it failed.

Fixed by removing the includes and fully qualifying the names in the tests.