### PR TITLE
Translation fix (bsc#1038077)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+*.pot
 .bundle
 .config
 coverage

--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May 19 11:41:59 UTC 2017 - lslezak@suse.cz
+
+- Translation fix: Ruby gettext cannot extract translatable texts
+  from interpolated strings (bsc#1038077)
+- 3.3.14
+
+-------------------------------------------------------------------
 Wed Oct 12 07:56:07 UTC 2016 - hguo@suse.com
 
 - Add a missing nil check in network fact reader.

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        3.3.13
+Version:        3.3.14
 Release:        0
 Url:            https://github.com/yast/yast-auth-client
 Summary:        YaST2 - Centralised System Authentication Configuration

--- a/src/lib/auth/authconf.rb
+++ b/src/lib/auth/authconf.rb
@@ -571,7 +571,7 @@ module Auth
             if exitstatus == 0
                 return ''
             end
-            return "#{_('ERROR: ')} #{out}\n#{errout}"
+            return _("ERROR: ") + "#{out}\n#{errout}"
         end
 
         # Parse and set Kerberos configuration


### PR DESCRIPTION
Ruby gettext cannot extract translatable texts from interpolated strings.

- 3.3.14