### PR TITLE
Bump to version 3.3.14 to fix three issues:

### DIFF
--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue May 23 13:00:19 UTC 2017 - hguo@suse.com
+
+- Bump to version 3.3.14 to fix three issues:
+  * Correctly install sss name databases even in the presence of
+    special NSS database directives (bsc#1024841).
+  * Fix missing translation of "Leave Domain" button (bsc#1038291).
+  * Do AD's DNS lookup in lower case (bsc#1038720).
+
+-------------------------------------------------------------------
 Wed Oct 12 07:56:07 UTC 2016 - hguo@suse.com
 
 - Add a missing nil check in network fact reader.

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        3.3.13
+Version:        3.3.14
 Release:        0
 Url:            https://github.com/yast/yast-auth-client
 Summary:        YaST2 - Centralised System Authentication Configuration

--- a/src/lib/auth/authconf.rb
+++ b/src/lib/auth/authconf.rb
@@ -121,9 +121,22 @@ module Auth
 
         # Enable the specified NSS database.
         def nss_enable_module(db_name, module_name)
-            names = Yast::Nsswitch.ReadDb(db_name)
-            return if names.include?(module_name)
-            Yast::Nsswitch.WriteDb(db_name, names + [module_name])
+            existing_names = Yast::Nsswitch.ReadDb(db_name)
+            return if existing_names.include?(module_name)
+            # Place new module in front of first conditional module
+            new_names = []
+            new_module_is_placed = false
+            existing_names.each { |name|
+                if name[0] == '['
+                    new_names << module_name
+                    new_module_is_placed = true
+                end
+                new_names << name
+            }
+            if !new_module_is_placed
+                new_names << module_name
+            end
+            Yast::Nsswitch.WriteDb(db_name, new_names)
             Yast::Nsswitch.Write
         end
 

--- a/src/lib/auth/authconf.rb
+++ b/src/lib/auth/authconf.rb
@@ -986,7 +986,7 @@ module Auth
         # Return the PDC host name of the given AD domain via DNS lookup. If it cannot be found, return an empty string.
         def ad_find_pdc(ad_domain_name)
             begin
-                return Resolv::DNS.new.getresource("_ldap._tcp.pdc._msdcs.#{ad_domain_name}", Resolv::DNS::Resource::IN::SRV).target.to_s
+                return Resolv::DNS.new.getresource("_ldap._tcp.pdc._msdcs.#{ad_domain_name}".downcase, Resolv::DNS::Resource::IN::SRV).target.to_s
             rescue Resolv::ResolvError
                 return ''
             end
@@ -996,7 +996,7 @@ module Auth
         # Return the KDC host name of the given AD domain via DNS lookup. If it cannot be found, return an empty string.
         def ad_find_kdc(ad_domain_name)
             begin
-                return Resolv::DNS.new.getresource("_kerberos._tcp.dc._msdcs.#{ad_domain_name}", Resolv::DNS::Resource::IN::SRV).target.to_s
+                return Resolv::DNS.new.getresource("_kerberos._tcp.dc._msdcs.#{ad_domain_name}".downcase, Resolv::DNS::Resource::IN::SRV).target.to_s
             rescue Resolv::ResolvError
                 return ''
             end

--- a/src/lib/authui/autoclient.rb
+++ b/src/lib/authui/autoclient.rb
@@ -42,9 +42,13 @@ module Auth
         def import(exported)
             if exported.has_key?('sssd')
                 # Import legacy XML configuration from SLE 12 SP0 or SP1
-                enabled = exported.fetch('sssd', nil)
-                daemon = exported.fetch('sssd_conf', {}).fetch('sssd', nil)
-                domain = exported.fetch('sssd_conf', {}).fetch('auth_domains', {}).fetch('domain', {})
+                sssd = exported['sssd']
+                if sssd.has_key?('listentry')
+                    sssd = sssd['listentry']
+                end
+                enabled = sssd.fetch('sssd', nil)
+                daemon = sssd.fetch('sssd_conf', {}).fetch('sssd', nil)
+                domain = sssd.fetch('sssd_conf', {}).fetch('auth_domains', {}).fetch('domain', {})
                 domain_name = domain.fetch('domain_name', nil)
                 if enabled != 'yes' || daemon.nil? || domain_name.nil?
                     log.info('legacy configuration is empty or disabled')

--- a/src/lib/authui/sssd/main_dialog.rb
+++ b/src/lib/authui/sssd/main_dialog.rb
@@ -217,7 +217,7 @@ module SSSD
                             Popup.Error(_("Please select a domain among the list."))
                             redo
                         end
-                        if !Popup.YesNo(_("Do you really wish to erase configuration for domain %s?" % sect_name))
+                        if !Popup.YesNo(_("Do you really wish to erase configuration for domain %s?") % sect_name)
                             redo
                         end
                         AuthConfInst.sssd_conf.delete(sect_name)


### PR DESCRIPTION
 * Correctly install sss name databases even in the presence of
   special NSS database directives (bsc#1024841).
 * Fix missing translation of "Leave Domain" button (bsc#1038291).
 * Do AD's DNS lookup in lower case (bsc#1038720).
