### PR TITLE
Bump to version 3.3.15 to fix four issues

### DIFF
--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Jun 16 13:47:40 UTC 2017 - hguo@suse.com
+
+- Bump to version 3.3.16 to fix minor issues across UI and backend:
+  * Fix misspelt kerberos option name "noaddresses".
+  * Improve UI captions, consistency.
+  * Introduce module name "auth" as an alias to "auth-client".
+  for bsc#1043211, bsc#1043184, bsc#1032733.
+
+-------------------------------------------------------------------
 Tue May 23 13:00:19 UTC 2017 - hguo@suse.com
 
 - Bump to version 3.3.15 to fix four issues:

--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,9 +1,11 @@
 -------------------------------------------------------------------
-Mon Aug 28 12:17:21 UTC 2017 - hguo@suse.com
+Tue Aug 29 13:54:21 UTC 2017 - hguo@suse.com
 
-- Bump to version 3.3.17 to fix a kerberos config file parser that
-  would mistakenly remove default_ccache_name key.
-  (bsc#1054436)
+- Bump to version 3.3.17 to fix two issues:
+  * Mistake in kerberos config file parser removes default_ccache_name
+    key (bsc#1054436).
+  * PAM configuration did not allow local user login if pam_unix2 is
+    in use (bsc#1056158).
 
 -------------------------------------------------------------------
 Fri Jun 16 13:47:40 UTC 2017 - hguo@suse.com

--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 28 12:17:21 UTC 2017 - hguo@suse.com
+
+- Bump to version 3.3.17 to fix a kerberos config file parser that
+  would mistakenly remove default_ccache_name key.
+  (bsc#1054436)
+
+-------------------------------------------------------------------
 Fri Jun 16 13:47:40 UTC 2017 - hguo@suse.com
 
 - Bump to version 3.3.16 to fix minor issues across UI and backend:

--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Tue May 23 13:00:19 UTC 2017 - hguo@suse.com
+
+- Bump to version 3.3.15 to fix four issues:
+  * Correctly install sss name databases even in the presence of
+    special NSS database directives (bsc#1024841).
+  * Fix missing translation of "Leave Domain" button (bsc#1038291).
+  * Do AD's DNS lookup in lower case (bsc#1038720).
+  * Understand XML data exported by SLES 12 SP0 (bsc#1040393).
+
+-------------------------------------------------------------------
 Fri May 19 11:41:59 UTC 2017 - lslezak@suse.cz
 
 - Translation fix: Ruby gettext cannot extract translatable texts

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        3.3.15
+Version:        3.3.16
 Release:        0
 Url:            https://github.com/yast/yast-auth-client
 Summary:        YaST2 - Centralised System Authentication Configuration

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        3.3.14
+Version:        3.3.15
 Release:        0
 Url:            https://github.com/yast/yast-auth-client
 Summary:        YaST2 - Centralised System Authentication Configuration

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        3.3.16
+Version:        3.3.17
 Release:        0
 Url:            https://github.com/yast/yast-auth-client
 Summary:        YaST2 - Centralised System Authentication Configuration

--- a/src/clients/auth.rb
+++ b/src/clients/auth.rb
@@ -1,0 +1,28 @@
+# encoding: utf-8
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE Linux GmbH.
+#
+# ------------------------------------------------------------------------------
+
+# Module:       Configure system-wide authentication mechanisms via SSSD
+# Summary:      Invoke main dialog and allow configuring SSSD, this is an alias of
+#               less appropriately named "auth-client".
+# Authors:      Howard Guo <hguo@suse.com>
+
+require 'auth/authconf'
+require 'authui/main_dialog'
+
+Auth::AuthConfInst.read_all
+Auth::MainDialog.new(:sssd).run

--- a/src/lib/auth/authconf.rb
+++ b/src/lib/auth/authconf.rb
@@ -121,9 +121,22 @@ module Auth
 
         # Enable the specified NSS database.
         def nss_enable_module(db_name, module_name)
-            names = Yast::Nsswitch.ReadDb(db_name)
-            return if names.include?(module_name)
-            Yast::Nsswitch.WriteDb(db_name, names + [module_name])
+            existing_names = Yast::Nsswitch.ReadDb(db_name)
+            return if existing_names.include?(module_name)
+            # Place new module in front of first conditional module
+            new_names = []
+            new_module_is_placed = false
+            existing_names.each { |name|
+                if name[0] == '['
+                    new_names << module_name
+                    new_module_is_placed = true
+                end
+                new_names << name
+            }
+            if !new_module_is_placed
+                new_names << module_name
+            end
+            Yast::Nsswitch.WriteDb(db_name, new_names)
             Yast::Nsswitch.Write
         end
 

--- a/src/lib/auth/authconf.rb
+++ b/src/lib/auth/authconf.rb
@@ -169,7 +169,7 @@ module Auth
         # Be extra careful with making changes.
         # Return replacement lines after adjustments.
         def pam_fix_auth(original_lines)
-            sufficient_auth = ['pam_unix.so', 'pam_sss.so', 'pam_ldap.so', 'pam_krb5.so']
+            sufficient_auth = ['pam_unix.so', 'pam_unix2.so', 'pam_sss.so', 'pam_ldap.so', 'pam_krb5.so']
             ret = []
             original_lines.each { |line|
                 line.strip!
@@ -209,7 +209,7 @@ module Auth
                 line.strip!
                 columns = line.split(/\s+/)
                 if !/\s*#/.match(line) && columns.length >= 3
-                    if columns[2] == 'pam_unix.so'
+                    if columns[2] == 'pam_unix.so' || columns[2] == 'pam_unix2.so'
                         ret.push(columns.join('    '))
                         ret.push('account    sufficient    pam_localuser.so')
                     elsif columns[2] != 'pam_localuser.so'

--- a/src/lib/auth/authconf.rb
+++ b/src/lib/auth/authconf.rb
@@ -986,7 +986,7 @@ module Auth
         # Return the PDC host name of the given AD domain via DNS lookup. If it cannot be found, return an empty string.
         def ad_find_pdc(ad_domain_name)
             begin
-                return Resolv::DNS.new.getresource("_ldap._tcp.pdc._msdcs.#{ad_domain_name}", Resolv::DNS::Resource::IN::SRV).target.to_s
+                return Resolv::DNS.new.getresource("_ldap._tcp.pdc._msdcs.#{ad_domain_name}".downcase, Resolv::DNS::Resource::IN::SRV).target.to_s
             rescue Resolv::ResolvError
                 return ''
             end
@@ -996,7 +996,7 @@ module Auth
         # Return the KDC host name of the given AD domain via DNS lookup. If it cannot be found, return an empty string.
         def ad_find_kdc(ad_domain_name)
             begin
-                return Resolv::DNS.new.getresource("_kerberos._tcp.dc._msdcs.#{ad_domain_name}", Resolv::DNS::Resource::IN::SRV).target.to_s
+                return Resolv::DNS.new.getresource("_kerberos._tcp.dc._msdcs.#{ad_domain_name}".downcase, Resolv::DNS::Resource::IN::SRV).target.to_s
             rescue Resolv::ResolvError
                 return ''
             end

--- a/src/lib/auth/krbparse.rb
+++ b/src/lib/auth/krbparse.rb
@@ -78,7 +78,7 @@ module Auth
                     next
                 end
                 # Note down key-value pairs in the current section
-                kv_match = /^\s*([.a-zA-Z0-9_-]+)\s*=\s*([^{}]+)\s*$/.match(line)
+                kv_match = /^\s*([.a-zA-Z0-9_-]+)\s*=\s*(.+)\s*$/.match(line)
                 if kv_match
                     if !new_krb_conf[sect]
                         new_krb_conf[sect] = {}

--- a/src/lib/authui/autoclient.rb
+++ b/src/lib/authui/autoclient.rb
@@ -42,9 +42,13 @@ module Auth
         def import(exported)
             if exported.has_key?('sssd')
                 # Import legacy XML configuration from SLE 12 SP0 or SP1
-                enabled = exported.fetch('sssd', nil)
-                daemon = exported.fetch('sssd_conf', {}).fetch('sssd', nil)
-                domain = exported.fetch('sssd_conf', {}).fetch('auth_domains', {}).fetch('domain', {})
+                sssd = exported['sssd']
+                if sssd.has_key?('listentry')
+                    sssd = sssd['listentry']
+                end
+                enabled = sssd.fetch('sssd', nil)
+                daemon = sssd.fetch('sssd_conf', {}).fetch('sssd', nil)
+                domain = sssd.fetch('sssd_conf', {}).fetch('auth_domains', {}).fetch('domain', {})
                 domain_name = domain.fetch('domain_name', nil)
                 if enabled != 'yes' || daemon.nil? || domain_name.nil?
                     log.info('legacy configuration is empty or disabled')

--- a/src/lib/authui/ldapkrb/edit_realm_dialog.rb
+++ b/src/lib/authui/ldapkrb/edit_realm_dialog.rb
@@ -57,9 +57,9 @@ module LdapKrb
                 VSpacing(1.0),
                 InputField(Id(:admin_server), Opt(:hstretch), _('Host Name of Administration Server (Optional)'),
                     AuthConfInst.krb_conf_get(['realms', @realm_name, 'admin_server'], '')),
-                InputField(Id(:master_kdc), Opt(:hstretch), _('Host Name of Master Key Distribution Server (Optional)'),
+                InputField(Id(:master_kdc), Opt(:hstretch), _('Host Name of Master Key Distribution Center (Optional)'),
                     AuthConfInst.krb_conf_get(['realms', @realm_name, 'master_kdc'], '')),
-                SelectionBox(Id(:kdc), Opt(:hstretch), _('Key Distribution Centres (Optional If Auto-Discovery via DNS is Enabled)'),
+                SelectionBox(Id(:kdc), Opt(:hstretch), _('Key Distribution Centers (Optional If Auto-Discovery via DNS is Enabled)'),
                     AuthConfInst.krb_conf_get(['realms', @realm_name, 'kdc'], [])),
                 Left(HBox(PushButton(Id(:kdc_add), Label.AddButton), PushButton(Id(:kdc_remove), Label.DeleteButton))),
                 VSpacing(1.0),
@@ -99,7 +99,7 @@ module LdapKrb
 
         # Add an auth_to_local
         def a2l_add_handler
-            new_a2l = GenericInputDialog.new(_('Please type in the auth_to_local rule:'), '').run
+            new_a2l = GenericInputDialog.new(_('Please type the new rule string (e.g. "RULE:[2:$1](johndoe)s/^.*$/guest/")'), '').run
             if !new_a2l.nil?
                 UI.ChangeWidget(Id(:auth_to_local), :Items, UI.QueryWidget(Id(:auth_to_local), :Items) + [new_a2l])
             end

--- a/src/lib/authui/ldapkrb/krb_extended_opts_dialog.rb
+++ b/src/lib/authui/ldapkrb/krb_extended_opts_dialog.rb
@@ -56,7 +56,7 @@ module LdapKrb
                 InputField(Id(:extra_addresses), Opt(:hstretch), _('Additional Addresses to be put in Ticket (Comma separated)'),
                     AuthConfInst.krb_conf_get(['libdefaults', 'extra_addresses'], '')),
                 VSpacing(1.0),
-                HBox(PushButton(Id(:reset), _('Reset')), PushButton(Id(:finish), Label.FinishButton)),
+                HBox(PushButton(Id(:reset), _('Reset')), PushButton(Id(:finish), Label.OKButton)),
             ))
         end
 

--- a/src/lib/authui/ldapkrb/ldap_extended_opts_dialog.rb
+++ b/src/lib/authui/ldapkrb/ldap_extended_opts_dialog.rb
@@ -51,7 +51,7 @@ module LdapKrb
                 IntField(Id(:ldap_timelimit), Opt(:hstretch), _('Timeout for Search Operations in Seconds'), 1, 600,
                            (AuthConfInst.ldap_conf['timelimit'].to_s == '' ? '30' : AuthConfInst.ldap_conf['timelimit']).to_i),
                 VSpacing(1.0),
-                PushButton(Id(:finish), Label.FinishButton)
+                PushButton(Id(:finish), Label.OKButton)
             ))
         end
 

--- a/src/lib/authui/ldapkrb/main_dialog.rb
+++ b/src/lib/authui/ldapkrb/main_dialog.rb
@@ -320,7 +320,7 @@ module LdapKrb
             end
             AuthConfInst.krb_conf['libdefaults']['forwardable'] = UI.QueryWidget(Id(:krb_forwardable), :Value)
             AuthConfInst.krb_conf['libdefaults']['proxiable'] = UI.QueryWidget(Id(:krb_proxiable), :Value)
-            AuthConfInst.krb_conf['libdefaults']['noaddress'] = UI.QueryWidget(Id(:krb_noaddress), :Value)
+            AuthConfInst.krb_conf['libdefaults']['noaddresses'] = UI.QueryWidget(Id(:krb_noaddresses), :Value)
             AuthConfInst.krb_conf['libdefaults']['dns_lookup_realm'] = UI.QueryWidget(Id(:krb_dns_lookup_realm), :Value)
             AuthConfInst.krb_conf['libdefaults']['dns_lookup_kdc'] = UI.QueryWidget(Id(:krb_dns_lookup_kdc), :Value)
             AuthConfInst.krb_conf['libdefaults']['allow_weak_crypto'] = UI.QueryWidget(Id(:krb_allow_weak_crypto), :Value)
@@ -422,8 +422,8 @@ module LdapKrb
                             AuthConfInst.krb_conf_get_bool(['libdefaults', 'forwardable'], false))),
                         Left(CheckBox(Id(:krb_proxiable), _('Allow Kerberos-Enabled Services to Take on The Identity Of a User'),
                             AuthConfInst.krb_conf_get_bool(['libdefaults', 'proxiable'], false))),
-                        Left(CheckBox(Id(:krb_noaddress), _('Issue Address-Less Tickets for Computers Behind NAT'),
-                            AuthConfInst.krb_conf_get_bool(['libdefaults', 'noaddress'], false))),
+                        Left(CheckBox(Id(:krb_noaddresses), _('Issue Address-Less Tickets for Computers Behind NAT'),
+                            AuthConfInst.krb_conf_get_bool(['libdefaults', 'noaddresses'], false))),
                         VSpacing(1.0),
                         Left(PushButton(Id(:krb_extended_opts), _('Extended Options'))),
                     )),

--- a/src/lib/authui/ldapkrb/main_dialog.rb
+++ b/src/lib/authui/ldapkrb/main_dialog.rb
@@ -413,7 +413,7 @@ module LdapKrb
                     Top(VBox(
                         Left(CheckBox(Id(:krb_dns_lookup_realm), _('Use DNS TXT Record to Discover Realms'),
                             AuthConfInst.krb_conf_get_bool(['libdefaults', 'dns_lookup_realm'], false))),
-                        Left(CheckBox(Id(:krb_dns_lookup_kdc), _('Use DNS SVC record to Discover KDC servers'),
+                        Left(CheckBox(Id(:krb_dns_lookup_kdc), _('Use DNS SRV record to Discover KDC servers'),
                             AuthConfInst.krb_conf_get_bool(['libdefaults', 'dns_lookup_kdc'], false))),
                         VSpacing(1.0),
                         Left(CheckBox(Id(:krb_allow_weak_crypto), _('Allow Insecure Encryption (Windows NT)'),

--- a/src/lib/authui/main_dialog.rb
+++ b/src/lib/authui/main_dialog.rb
@@ -60,13 +60,13 @@ module Auth
         end
 
         def dialog_content
-            conf_buttons = [PushButton(Id(:change_settings), _('Change Settings')), PushButton(Id(:finish), Label.FinishButton)]
+            conf_buttons = [PushButton(Id(:change_settings), _('Change Settings')), PushButton(Id(:finish), Label.OKButton)]
             if @entry_point == :auto
                 # Allow entering both SSSD and ldapkrb settings
                 conf_buttons = [
                     PushButton(Id(:change_sssd_settings), _('User Logon Configuration')),
                     PushButton(Id(:change_ldapkrb_settings), _('LDAP/Kerberos Configuration')),
-                    PushButton(Id(:finish), Label.FinishButton)
+                    PushButton(Id(:finish), Label.OKButton)
                 ]
             end
             VBox(

--- a/src/lib/authui/sssd/main_dialog.rb
+++ b/src/lib/authui/sssd/main_dialog.rb
@@ -88,7 +88,7 @@ module SSSD
                                 VSpacing(0.2),
                                 Tree(Id(:section_tree), Opt(:immediate), "", []),
                                 Left(HBox(
-                                    PushButton(Id(:new_domain), _("Join Domain")),
+                                    PushButton(Id(:new_domain), _("Add Domain")),
                                     PushButton(Id(:del_domain), _("Leave Domain")),
                                     PushButton(Id(:clear_cache), _("Clear Domain Cache"))
                                 )),

--- a/src/lib/authui/sssd/main_dialog.rb
+++ b/src/lib/authui/sssd/main_dialog.rb
@@ -217,7 +217,7 @@ module SSSD
                             Popup.Error(_("Please select a domain among the list."))
                             redo
                         end
-                        if !Popup.YesNo(_("Do you really wish to erase configuration for domain %s?" % sect_name))
+                        if !Popup.YesNo(_("Do you really wish to erase configuration for domain %s?") % sect_name)
                             redo
                         end
                         AuthConfInst.sssd_conf.delete(sect_name)

--- a/test/authconf_test.rb
+++ b/test/authconf_test.rb
@@ -194,6 +194,7 @@ module i/j/k.l:RESIDUAL
 #       default_realm = EXAMPLE.COM 
         default_realm = ABC.ZZZ
     forwardable = true
+    default_ccache_name = FILE:/tmp/krb5cc_%{uid}
 
 [realms]
 #       EXAMPLE.COM = {
@@ -249,7 +250,7 @@ suse.de = ABC.ZZZ
 ')
             expect(authconf.krb_export).to eq("conf"=>{
                 "include"=>["include a/b/c.d", "includedir e/f/g.h", "module i/j/k.l:RESIDUAL"],
-                    "libdefaults"=>{"default_realm"=>"ABC.ZZZ", "forwardable"=>"true"},
+                    "libdefaults"=>{"default_realm"=>"ABC.ZZZ", "forwardable"=>"true", "default_ccache_name"=>"FILE:/tmp/krb5cc_%{uid}"},
                     "realms"=>{
                         "ABC.ZZZ"=>{
                             "kdc"=>["howie.suse.de", "backup.howie.suse.de"],
@@ -286,6 +287,7 @@ module i/j/k.l:RESIDUAL
 [libdefaults]
     default_realm = ABC.ZZZ
     forwardable = true
+    default_ccache_name = FILE:/tmp/krb5cc_%{uid}
 
 [domain_realms]
     .suse.de = ABC.ZZZ

--- a/test/authconf_test.rb
+++ b/test/authconf_test.rb
@@ -427,6 +427,29 @@ auth    required        pam_ldap.so     use_first_pass
                 "auth    required    pam_deny.so"
             ]
         end
+
+        it 'Fix pam authentication configuration (unix2)' do
+            expect(authconf.pam_fix_auth("
+# comment
+auth    required        pam_env.so
+auth    optional        pam_gnome_keyring.so
+auth    sufficient      pam_unix2.so     try_first_pass
+auth    sufficient      pam_krb5.so     use_first_pass
+auth    sufficient      pam_sss.so      use_first_pass
+auth    required        pam_ldap.so     use_first_pass
+".split("\n"))).to eq [
+                "",
+                "# comment",
+                "auth    required        pam_env.so",
+                "auth    optional        pam_gnome_keyring.so",
+                "auth    sufficient    pam_unix2.so    try_first_pass",
+                "auth    sufficient    pam_krb5.so    use_first_pass",
+                "auth    sufficient    pam_sss.so    use_first_pass",
+                "auth    sufficient    pam_ldap.so    use_first_pass",
+                "auth    required    pam_deny.so"
+            ]
+        end
+
         it 'Fix pam account configuration' do
             expect(authconf.pam_fix_account("
 # comment
@@ -439,6 +462,25 @@ account required        pam_ldap.so     use_first_pass
                 "",
                 "# comment",
                 "account    requisite    pam_unix.so    try_first_pass",
+                "account    sufficient    pam_localuser.so",
+                "account required        pam_krb5.so     use_first_pass",
+                "account sufficient      pam_sss.so      use_first_pass",
+                "account required        pam_ldap.so     use_first_pass"
+            ]
+        end
+
+        it 'Fix pam account configuration (unix2)' do
+            expect(authconf.pam_fix_account("
+# comment
+account requisite       pam_unix2.so     try_first_pass
+account required        pam_krb5.so     use_first_pass
+account sufficient      pam_localuser.so
+account sufficient      pam_sss.so      use_first_pass
+account required        pam_ldap.so     use_first_pass
+".split("\n"))).to eq [
+                "",
+                "# comment",
+                "account    requisite    pam_unix2.so    try_first_pass",
                 "account    sufficient    pam_localuser.so",
                 "account required        pam_krb5.so     use_first_pass",
                 "account sufficient      pam_sss.so      use_first_pass",


### PR DESCRIPTION
* Correctly install sss name databases even in the presence of
    special NSS database directives (bsc#1024841).
  * Fix missing translation of "Leave Domain" button (bsc#1038291).
  * Do AD's DNS lookup in lower case (bsc#1038720).
  * Understand XML data exported by SLES 12 SP0 (bsc#1040393).
