### PR TITLE
fix reading of ssl setting from /etc/ldap.conf

### DIFF
--- a/src/lib/authui/ldapkrb/main_dialog.rb
+++ b/src/lib/authui/ldapkrb/main_dialog.rb
@@ -387,7 +387,7 @@ module LdapKrb
             else
                 UI.ChangeWidget(Id(:ldap_bind_policy), :CurrentButton, :ldap_bind_policy_hard)
             end
-            if AuthConfInst.ldap_conf['ssl'] == 'on'
+            if AuthConfInst.ldap_conf['ssl'] == 'yes'
                 UI.ChangeWidget(Id(:ldap_tls_method), :CurrentButton, :ldap_tls_method_yes)
             elsif AuthConfInst.ldap_conf['ssl'] == 'start_tls'
                 UI.ChangeWidget(Id(:ldap_tls_method), :CurrentButton, :ldap_tls_method_starttls)


### PR DESCRIPTION
Because of the key "ssl" is set to no|yes|start_tls, the key should be read likewise.