### PR TITLE
protect credentials in /etc/ldap.conf

### DIFF
--- a/src/lib/auth/authconf.rb
+++ b/src/lib/auth/authconf.rb
@@ -524,7 +524,7 @@ module Auth
             end
             # Write LDAP config file and correct its permission and ownerships
             ldap_conf = File.new('/etc/ldap.conf', 'w')
-            ldap_conf.chmod(600)
+            ldap_conf.chmod(0600)
             ldap_conf.chown(0, 0)
             ldap_conf.write(ldap_make_conf)
             ldap_conf.close

--- a/src/lib/auth/authconf.rb
+++ b/src/lib/auth/authconf.rb
@@ -524,7 +524,7 @@ module Auth
             end
             # Write LDAP config file and correct its permission and ownerships
             ldap_conf = File.new('/etc/ldap.conf', 'w')
-            ldap_conf.chmod(644)
+            ldap_conf.chmod(600)
             ldap_conf.chown(0, 0)
             ldap_conf.write(ldap_make_conf)
             ldap_conf.close


### PR DESCRIPTION
As /etc/ldap.conf may contain credentials when configured with yast, it shouldn't be world-readable. Successfully this change, but I'm not sure about side effects.