### PR TITLE
Default bind_policy to 'soft' if not present in the config

### DIFF
--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan  29 11:48:30 UTC 2020 - Jaroslav Jindrak <jjindrak@suse.cz>
+
+- Default bind_policy to 'soft' if not present in the config
+  (bsc#1162025).
+- 4.2.4
+
+-------------------------------------------------------------------
 Fri Nov  8 12:36:03 UTC 2019 - Samuel Cabrero <scabrero@suse.de>
 
 - Add missing domain setting 'ignore_group_members'; (bsc#1153547);

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Url:            https://github.com/yast/yast-auth-client
 Summary:        YaST2 - Centralised System Authentication Configuration

--- a/src/lib/authui/ldapkrb/main_dialog.rb
+++ b/src/lib/authui/ldapkrb/main_dialog.rb
@@ -306,6 +306,12 @@ module LdapKrb
             when :ldap_tls_method_starttls
                 AuthConfInst.ldap_conf['ssl'] = 'start_tls'
             end
+
+            # bsc#1162025: Default bind_policy to soft if not present.
+            if not AuthConfInst.ldap_conf.key?('bind_policy')
+              AuthConfInst.ldap_conf['bind_policy'] = 'soft'
+            end
+
             AuthConfInst.mkhomedir_pam = UI.QueryWidget(Id(:mkhomedir_enable), :Value)
         end
 


### PR DESCRIPTION
The situation, depending on how yast-auth-config and nss_ldap interact:

1) nss_ldap installed, yast-auth-config not used

The (original) /etc/ldap.conf file contains 'bind_policy soft'.

2) nss_ldap installed, original /etc/ldap.conf, yast-auth-config used:

The rewritten /etc/ldap.conf contains 'bind_policy soft'.

3) nss_ldap not installed, /etc/ldap.conf does not exist, yast-auth-config used:

The package nss_ldap gets installed, but YaST sees non-existent /etc/ldap.conf when loading and overwrites the newly created /etc/ldap.conf (created through installation of nss_ldap) with one that does not contain any bind_policy. This makes nss_ldap default to 'hard_open', which causes the system not to boot (no network present but ldap keeps trying to connect).

This patch adds 'bind_policy soft' to the config if the option was not present in the config previously (e.g. because the config file does not exist). This of course means that one cannot rely on the default and to achieve the effect of 'hard_open' one has to explicitly request that in the config file, though I personally see that as a reasonable trade-off.

Fixes bsc#1162025.