### PR TITLE
Section name is 'domain_realm' not 'domain_realms'

### DIFF
--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 10 10:02:52 UTC 2020 - Samuel Cabrero <scabrero@suse.de>
+
+- yast auth-client and krb5.conf wrong domain_realm entry; (bsc#1122026)
+- 3.3.15
+
+-------------------------------------------------------------------
 Fri May 19 11:41:59 UTC 2017 - lslezak@suse.cz
 
 - Translation fix: Ruby gettext cannot extract translatable texts

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        3.3.14
+Version:        3.3.15
 Release:        0
 Url:            https://github.com/yast/yast-auth-client
 Summary:        YaST2 - Centralised System Authentication Configuration

--- a/src/lib/auth/authconf.rb
+++ b/src/lib/auth/authconf.rb
@@ -41,7 +41,7 @@ module Auth
         # Clear all configuration objects.
         def clear
             # Kerberos configuration
-            @krb_conf = {'include' => [], 'libdefaults' => {}, 'realms' => {}, 'domain_realms' => {}, 'logging' => {}}
+            @krb_conf = {'include' => [], 'libdefaults' => {}, 'realms' => {}, 'domain_realm' => {}, 'logging' => {}}
             @krb_pam = false
             # LDAP configuration (/etc/ldap.conf)
             @ldap_conf = {}
@@ -661,7 +661,7 @@ module Auth
 
         # Make sure the Kerberos configuration has all the necessary keys.
         def krb_lint_conf
-            ['libdefaults', 'realms', 'domain_realms', 'logging'].each { |key|
+            ['libdefaults', 'realms', 'domain_realm', 'logging'].each { |key|
                 @krb_conf[key] = {} if @krb_conf[key].nil?
             }
             @krb_conf['include'] = [] if @krb_conf['include'].nil?
@@ -781,10 +781,10 @@ module Auth
             end
             @krb_conf['realms'][realm_name].merge!("kdc" => kdc_addr, "admin_server" => admin_addr)
             if make_domain_realms
-                @krb_conf['domain_realms'].merge!(".#{realm_name.downcase}" => realm_name, "#{realm_name.downcase}" => realm_name)
+                @krb_conf['domain_realm'].merge!(".#{realm_name.downcase}" => realm_name, "#{realm_name.downcase}" => realm_name)
             else
-                @krb_conf['domain_realms'].delete(".#{realm_name.downcase}")
-                @krb_conf['domain_realms'].delete("#{realm_name.downcase}")
+                @krb_conf['domain_realm'].delete(".#{realm_name.downcase}")
+                @krb_conf['domain_realm'].delete("#{realm_name.downcase}")
             end
             if make_default || @krb_conf['libdefaults']['default_realm'].to_s == ''
                 @krb_conf['libdefaults']['default_realm'] = realm_name

--- a/src/lib/auth/krbparse.rb
+++ b/src/lib/auth/krbparse.rb
@@ -26,7 +26,7 @@ module Auth
             long_attr1 = ''
             long_attr2 = ''
             sect = ''
-            new_krb_conf = {'include' => [], 'libdefaults' => {}, 'realms' => {}, 'domain_realms' => {}, 'logging' => {}}
+            new_krb_conf = {'include' => [], 'libdefaults' => {}, 'realms' => {}, 'domain_realm' => {}, 'logging' => {}}
             # Break down sections and key-value pairs
             krb_conf_text.split(/\n/).each{ |line|
                 # Throw away comment
@@ -45,6 +45,16 @@ module Auth
                 if sect_match
                     # remember current section
                     sect = sect_match[1]
+                    # Bug 1122026: krb5.conf sections can have a variable amount
+                    # of characters appended to the name, and still be valid.
+                    # domain_realm for example could have an 's' appended, but
+                    # is not the documented section title.
+                    new_krb_conf.each { |k, v|
+                        if sect_match[1].start_with?(k)
+                            sect = k
+                            break
+                        end
+                    }
                     next
                 end
                 # Remember expanded attribute

--- a/src/lib/authui/ldapkrb/edit_realm_dialog.rb
+++ b/src/lib/authui/ldapkrb/edit_realm_dialog.rb
@@ -51,9 +51,9 @@ module LdapKrb
             VBox(
                 InputField(Id(:realm_name), Opt(:hstretch), _('Realm name'), @realm_name.to_s),
                 CheckBox(Id(:map_domain), Opt(:hstretch), _('Map Domain Name to the Realm (example.com -> EXAMPLE.COM)'),
-                    !@realm_name.nil? && !AuthConfInst.krb_conf_get(['domain_realms', @realm_name.downcase], nil).nil?),
+                    !@realm_name.nil? && !AuthConfInst.krb_conf_get(['domain_realm', @realm_name.downcase], nil).nil?),
                 CheckBox(Id(:map_wildcard_domain), Opt(:hstretch), _('Map Wild Card Domain Name to the Realm (*.example.com -> EXAMPLE.COM)'),
-                    !@realm_name.nil? && !AuthConfInst.krb_conf_get(['domain_realms', ".#{@realm_name.downcase}"], nil).nil?),
+                    !@realm_name.nil? && !AuthConfInst.krb_conf_get(['domain_realm', ".#{@realm_name.downcase}"], nil).nil?),
                 VSpacing(1.0),
                 InputField(Id(:admin_server), Opt(:hstretch), _('Host Name of Administration Server (Optional)'),
                     AuthConfInst.krb_conf_get(['realms', @realm_name, 'admin_server'], '')),
@@ -142,9 +142,9 @@ module LdapKrb
                 if AuthConfInst.krb_conf['libdefaults']['default_realm'] == @realm_name
                     AuthConfInst.krb_conf['libdefaults']['default_realm'] = input_realm_name
                 end
-                domains = AuthConfInst.krb_conf['domain_realms'].select{ |_, realm| realm == @realm_name}.keys
-                domains.each {|domain| AuthConfInst.krb_conf['domain_realms'].delete(domain)}
-                domains.each {|domain| AuthConfInst.krb_conf['domain_realms'][domain] = input_realm_name}
+                domains = AuthConfInst.krb_conf['domain_realm'].select{ |_, realm| realm == @realm_name}.keys
+                domains.each {|domain| AuthConfInst.krb_conf['domain_realm'].delete(domain)}
+                domains.each {|domain| AuthConfInst.krb_conf['domain_realm'][domain] = input_realm_name}
             end
             # Create new realm
             if !AuthConfInst.krb_conf['realms'].include?(input_realm_name)
@@ -156,14 +156,14 @@ module LdapKrb
             realm_conf['master_kdc'] = UI.QueryWidget(Id(:master_kdc), :Value)
             realm_conf['kdc'] = UI.QueryWidget(Id(:kdc), :Items).map{|item| item[1]}
             if UI.QueryWidget(Id(:map_domain), :Value)
-                AuthConfInst.krb_conf['domain_realms'][input_realm_name.downcase] = input_realm_name
+                AuthConfInst.krb_conf['domain_realm'][input_realm_name.downcase] = input_realm_name
             else
-                AuthConfInst.krb_conf['domain_realms'].delete(input_realm_name.downcase)
+                AuthConfInst.krb_conf['domain_realm'].delete(input_realm_name.downcase)
             end
             if UI.QueryWidget(Id(:map_wildcard_domain), :Value)
-                AuthConfInst.krb_conf['domain_realms'][".#{input_realm_name.downcase}"] = input_realm_name
+                AuthConfInst.krb_conf['domain_realm'][".#{input_realm_name.downcase}"] = input_realm_name
             else
-                AuthConfInst.krb_conf['domain_realms'].delete(".#{input_realm_name.downcase}")
+                AuthConfInst.krb_conf['domain_realm'].delete(".#{input_realm_name.downcase}")
             end
             realm_conf['auth_to_local'] = UI.QueryWidget(Id(:auth_to_local), :Items).map{|item| item[1]}
             realm_conf['auth_to_local_names'] = Hash[*UI.QueryWidget(Id(:auth_to_local_names), :Items).map{|item| [item[1], item[2]]}.flatten]

--- a/src/lib/authui/ldapkrb/main_dialog.rb
+++ b/src/lib/authui/ldapkrb/main_dialog.rb
@@ -200,7 +200,7 @@ module LdapKrb
                             redo
                         end
                         if Popup.YesNo(_('Are you sure to delete realm %s?') % [realm_name])
-                            AuthConfInst.krb_conf['domain_realms'].delete_if{ |_, domain_realm| domain_realm == realm_name}
+                            AuthConfInst.krb_conf['domain_realm'].delete_if{ |_, domain_realm| domain_realm == realm_name}
                             if UI.QueryWidget(Id(:krb_default_realm), :Value) == realm_name
                                 UI.ChangeWidget(Id(:krb_default_realm), :Value, _('(not specified)'))
                             end

--- a/test/authconf_test.rb
+++ b/test/authconf_test.rb
@@ -183,9 +183,33 @@ ssl start_tls
                             "auth_to_local"=>["RULE:[2:$1](johndoe)s/^.*$/guest/"]
                         },
                     },
-                    "domain_realms"=>{}, "logging"=>{}
+                    "domain_realm"=>{}, "logging"=>{}
                 }, "pam"=>false)
-            # The second example is very comprehensive
+            # The second tests for cruft in the section names
+            authconf.krb_parse_set('
+[libdefaultsXXXXXXXXX]
+    default_realm = ABC.ZZZ
+
+[realmsYYYZZZZXXXXX]
+        ABC.ZZZ = {
+            kdc = howie.suse.de
+            admin_server = howie.suse.de
+            auth_to_local = RULE:[2:$1](johndoe)s/^.*$/guest/
+        }
+')
+            expect(authconf.krb_export).to eq("conf"=>{
+                    "include"=>[],
+                    "libdefaults"=>{"default_realm"=>"ABC.ZZZ"},
+                    "realms"=>{
+                        "ABC.ZZZ"=>{
+                            "kdc"=>["howie.suse.de"],
+                            "admin_server"=>"howie.suse.de",
+                            "auth_to_local"=>["RULE:[2:$1](johndoe)s/^.*$/guest/"]
+                        },
+                    },
+                    "domain_realm"=>{}, "logging"=>{}
+                }, "pam"=>false)
+            # The third example is very comprehensive
             authconf.krb_parse_set('include a/b/c.d
 includedir e/f/g.h
 module i/j/k.l:RESIDUAL
@@ -222,7 +246,7 @@ module i/j/k.l:RESIDUAL
         EMPTY.NET = {
         }
 
-[domain_realms]
+[domain_realm]
 .suse.de = ABC.ZZZ
 suse.de = ABC.ZZZ
 
@@ -262,7 +286,7 @@ suse.de = ABC.ZZZ
                         },
                         "EMPTY.NET"=> {},
                     },
-                    "domain_realms"=>{".suse.de"=>"ABC.ZZZ", "suse.de"=>"ABC.ZZZ"},
+                    "domain_realm"=>{".suse.de"=>"ABC.ZZZ", "suse.de"=>"ABC.ZZZ"},
                     "logging"=>{"kdc"=>"FILE:/var/log/krb5/krb5kdc.log", "admin_server"=>"FILE:/var/log/krb5/kadmind.log", "default"=>"SYSLOG:NOTICE:DAEMON"},
                     "dbmodules"=>{
                         "openldap_ldapconf"=>{
@@ -287,7 +311,7 @@ module i/j/k.l:RESIDUAL
     default_realm = ABC.ZZZ
     forwardable = true
 
-[domain_realms]
+[domain_realm]
     .suse.de = ABC.ZZZ
     suse.de = ABC.ZZZ
 
@@ -336,7 +360,7 @@ module i/j/k.l:RESIDUAL
                 {"ABC.ZZZ"=>{"kdc"=>["howie.suse.de"], "admin_server"=>"howie.suse.de"},
                  "ABD.ZZZ"=>{"kdc"=>["howie2.suse.de"], "admin_server"=>"howie2.suse.de"}},
                "libdefaults"=>{"default_realm"=>"ABC.ZZZ", "forwardable"=>"true"},
-               "domain_realms"=>{".suse.de"=>"ABC.ZZZ", "suse.de"=>"ABC.ZZZ"},
+               "domain_realm"=>{".suse.de"=>"ABC.ZZZ", "suse.de"=>"ABC.ZZZ"},
                "logging"=>
                 {"kdc"=>"FILE:/var/log/krb5/krb5kdc.log",
                  "admin_server"=>"FILE:/var/log/krb5/kadmind.log",
@@ -349,7 +373,7 @@ module i/j/k.l:RESIDUAL
             conf = {"conf"=>
               {"realms"=>{},
                "libdefaults"=>{},
-               "domain_realms"=>{},
+               "domain_realm"=>{},
                "logging"=>
                 {"kdc"=>"FILE:/var/log/krb5/krb5kdc.log",
                  "admin_server"=>"FILE:/var/log/krb5/kadmind.log",
@@ -361,7 +385,7 @@ module i/j/k.l:RESIDUAL
               {"realms"=>
                 {"ABC.ZZZ"=>{"kdc"=>"howie.suse.de", "admin_server"=>"howie2.suse.de"}},
                "libdefaults"=>{"default_realm"=>"ABC.ZZZ"},
-               "domain_realms"=>{".abc.zzz"=>"ABC.ZZZ", "abc.zzz"=>"ABC.ZZZ"},
+               "domain_realm"=>{".abc.zzz"=>"ABC.ZZZ", "abc.zzz"=>"ABC.ZZZ"},
                "logging"=>
                 {"kdc"=>"FILE:/var/log/krb5/krb5kdc.log",
                  "admin_server"=>"FILE:/var/log/krb5/kadmind.log",
@@ -372,7 +396,7 @@ module i/j/k.l:RESIDUAL
               {"realms"=>
                 {"ABC.ZZZ"=>{"kdc"=>"3.suse.de", "admin_server"=>"4.suse.de"}},
                "libdefaults"=>{"default_realm"=>"ABC.ZZZ"},
-               "domain_realms"=>{},
+               "domain_realm"=>{},
                "logging"=>
                 {"kdc"=>"FILE:/var/log/krb5/krb5kdc.log",
                  "admin_server"=>"FILE:/var/log/krb5/kadmind.log",


### PR DESCRIPTION
MIT Kerberos accepts arbitrary strings at the end
of section names (in this case 's'), but some
applications (such as SAP HANA) cannot handle the
invalid section title; (bsc#1122026)