### PR TITLE
Allow to define the dnsHostName attribute when joining (bsc#1200964)

### DIFF
--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug  1 15:50:38 UTC 2022 - Samuel Cabrero <scabrero@suse.de>
+
+- Allow to define the dnsHostName attribute when joining to AD;
+  (bsc#1200964);
+- 4.5.2
+
+-------------------------------------------------------------------
 Wed Jul 27 00:50:39 UTC 2022 - William Brown <william.brown@suse.com>
 
 - Remove nss_ldap and pam_ldap support in favour of SSSD

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 Url:            https://github.com/yast/yast-auth-client
 Summary:        YaST2 - Centralised System Authentication Configuration

--- a/src/lib/auth/authconf.rb
+++ b/src/lib/auth/authconf.rb
@@ -36,7 +36,7 @@ module Auth
 
         attr_accessor(:krb_conf, :krb_pam, :ldap_pam, :ldap_nss, :sssd_conf, :sssd_pam, :sssd_nss, :sssd_enabled)
         attr_accessor(:autofs_enabled, :nscd_enabled, :mkhomedir_pam)
-        attr_accessor(:ad_domain, :ad_user, :ad_ou, :ad_pass, :ad_overwrite_smb_conf, :ad_update_dns, :autoyast_editor_mode, :autoyast_modified)
+        attr_accessor(:ad_domain, :ad_user, :ad_ou, :ad_pass, :ad_overwrite_smb_conf, :ad_update_dns, :ad_dnshostname, :autoyast_editor_mode, :autoyast_modified)
 
         # Clear all configuration objects.
         def clear
@@ -67,6 +67,7 @@ module Auth
             @ad_ou = ''
             @ad_pass = ''
             @ad_update_dns = true
+            @ad_dnshostname = ''
             @ad_overwrite_smb_conf = false
         end
 
@@ -824,7 +825,8 @@ module Auth
         # Return AD enrollment configuration.
         def ad_export
             return {'domain' => @ad_domain, 'user' => @ad_user, 'ou' => @ad_ou, 'pass' => @ad_pass,
-                     'overwrite_smb_conf' => @ad_overwrite_smb_conf, 'update_dns' => @ad_update_dns}
+                    'overwrite_smb_conf' => @ad_overwrite_smb_conf, 'update_dns' => @ad_update_dns,
+                    'dnshostname' => @ad_dnshostname}
         end
 
         # Set configuration for AD enrollment from exported objects.
@@ -836,6 +838,7 @@ module Auth
                 @ad_pass = ''
                 @ad_overwrite_smb_conf = false
                 @ad_update_dns = false
+                @ad_dnshostname = ''
             else
                 @ad_domain = exported_conf['domain']
                 @ad_user = exported_conf['user']
@@ -843,6 +846,7 @@ module Auth
                 @ad_pass= exported_conf['pass']
                 @ad_overwrite_smb_conf = exported_conf['overwrite_smb_conf']
                 @ad_update_dns = exported_conf['update_dns']
+                @ad_dnshostname = exported_conf['dnshostname']
             end
         end
 
@@ -870,7 +874,8 @@ module Auth
             output = ''
             exitstatus = 0
             ou_param = @ad_ou.to_s == '' ? '' : "createcomputer=#{@ad_ou}"
-            netcmd = "net -s #{smb_conf.path} ads join #{ou_param} -U #{@ad_user}"
+            dnshostname_param = @ad_dnshostname.to_s == '' ? '' : "dnshostname=#{@ad_dnshostname}"
+            netcmd = "net -s #{smb_conf.path} ads join #{ou_param} #{dnshostname_param} -U #{@ad_user}"
             if !@ad_update_dns
                 netcmd += ' --no-dns-updates'
             end

--- a/src/lib/authui/autoclient.rb
+++ b/src/lib/authui/autoclient.rb
@@ -155,6 +155,7 @@ module Auth
             AuthConfInst.ad_user = ''
             AuthConfInst.ad_ou = ''
             AuthConfInst.ad_pass = ''
+            AuthConfInst.ad_dnshostname = ''
             AuthConfInst.ad_overwrite_smb_conf = false
             AuthConfInst.autoyast_modified = true
             return true

--- a/src/lib/authui/sssd/manage_ad_dialog.rb
+++ b/src/lib/authui/sssd/manage_ad_dialog.rb
@@ -70,6 +70,7 @@ module SSSD
                     Password(Id(:password), Opt(:hstretch), _('Password'), AuthConfInst.ad_pass),
                     CheckBox(Id(:update_dns), Opt(:hstretch), _('Update AD\'s DNS records as well'), AuthConfInst.ad_update_dns),
                     InputField(Id(:orgunit), Opt(:hstretch), _('Optional Organisation Unit such as "Headquarter/HR/BuildingA"'), AuthConfInst.ad_ou),
+                    InputField(Id(:dnshostname), Opt(:hstretch), _('Optional dnsHostName attribute during the join'), AuthConfInst.ad_dnshostname),
                     Left(CheckBox(Id(:overwrite_smb_conf), _('Overwrite Samba configuration to work with this AD'), AuthConfInst.ad_overwrite_smb_conf)),
             )
             ad_entry = ''
@@ -128,6 +129,7 @@ module SSSD
             orgunit = UI.QueryWidget(Id(:orgunit), :Value)
             password = UI.QueryWidget(Id(:password), :Value)
             overwrite_smb_conf = UI.QueryWidget(Id(:overwrite_smb_conf), :Value)
+            dnshostname = UI.QueryWidget(Id(:dnshostname), :Value)
 
             if !username.nil? && username != '' || !password.nil? && password != '' || !orgunit.nil? && orgunit != ''
                 # Enroll the computer, or save the enrollment details
@@ -140,6 +142,7 @@ module SSSD
                 AuthConfInst.ad_user = username
                 AuthConfInst.ad_ou = orgunit
                 AuthConfInst.ad_pass = password
+                AuthConfInst.ad_dnshostname = dnshostname
                 AuthConfInst.ad_update_dns = UI.QueryWidget(Id(:update_dns), :Value)
                 AuthConfInst.ad_overwrite_smb_conf = overwrite_smb_conf
                 if AuthConfInst.autoyast_editor_mode
@@ -154,6 +157,7 @@ module SSSD
                     AuthConfInst.ad_user = ''
                     AuthConfInst.ad_ou = ''
                     AuthConfInst.ad_pass = ''
+                    AuthConfInst.ad_dnshostname = ''
                     finish_dialog(:finish)
                     return
                 else


### PR DESCRIPTION
## Problem

auth-client does not expose `net ads join` parameter to set the machine name differently from the current host name (`dnshostname=<FQDN>`)

https://bugzilla.suse.com/show_bug.cgi?id=1200964


## Solution

Add a new textbox to optionally define this parameter


## Testing

- *Tested manually*


## Screenshots

![Screenshot from 2022-08-01 17-45-18](https://user-images.githubusercontent.com/1259034/182189949-0c52f1ff-6680-4991-a3dc-c2f496a1b24b.png)


