### PR TITLE
Bsc1202919

### DIFF
--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 31 07:27:37 UTC 2022 - Michal Filka <mfilka@suse.com>
+
+- bsc#1202919
+  - fixed internal error. Do not call function removed in 4.4.3
+- 4.4.4
+
+-------------------------------------------------------------------
 Tue Aug  2 11:12:22 UTC 2022 - Samuel Cabrero <scabrero@suse.de>
 
 - Remove nss_ldap and pam_ldap support in favour of SSSD;

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        4.4.3
+Version:        4.4.4
 Release:        0
 Url:            https://github.com/yast/yast-auth-client
 Summary:        YaST2 - Centralised System Authentication Configuration

--- a/src/lib/authui/autoclient.rb
+++ b/src/lib/authui/autoclient.rb
@@ -133,7 +133,6 @@ module Auth
         # Apply all configuration.
         def write
             AuthConfInst.autoyast_editor_mode = false
-            AuthConfInst.ldap_apply
             AuthConfInst.krb_apply
             AuthConfInst.aux_apply
             # If there is an AD domain, it has to join before SSSD is started


### PR DESCRIPTION
## Problem

Crash caused by calling method which was dropped in https://github.com/yast/yast-auth-client/pull/110/

(https://bugzilla.suse.com/show_bug.cgi?id=1202919)

## Solution

Dropped the call


