### PR TITLE
Stop using File.exists? which no longer works in Ruby 3.2 (bsc#1206419)

### DIFF
--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar  6 16:47:05 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Stop using File.exists? which no longer works in Ruby 3.2
+  (bsc#1206419)
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.6.0 (bsc#1208913)

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Url:            https://github.com/yast/yast-auth-client
 Summary:        YaST2 - Centralised System Authentication Configuration

--- a/src/lib/auth/authconf.rb
+++ b/src/lib/auth/authconf.rb
@@ -409,7 +409,7 @@ module Auth
                 end
             end
             # Write SSSD config file and correct its permission and ownerships
-            if File.exists?('/etc/sssd')
+            if File.exist?('/etc/sssd')
                 sssd_conf = File.new('/etc/sssd/sssd.conf', 'w')
                 sssd_conf.chmod(0600)
                 sssd_conf.chown(0, 0)


### PR DESCRIPTION
## Problem


Ruby 3.2 removed `File.exists?` which has been long deprecated in favor of `File.exist?`

Here it would always fail when writing the config. The method `sssd_apply` is not covered by tests.

- https://trello.com/c/jRe5bWVE
- https://bugzilla.suse.com/show_bug.cgi?id=1206419

## Solution

Fix method name

## Testing

- [ ] Added a new unit test


## Screenshots

N/A
