### PR TITLE
Backport sp6

### DIFF
--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 04 16:47:05 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Stop using File.exists? which no longer works in Ruby 3.2
+  (bsc#1206419)
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 Url:            https://github.com/yast/yast-auth-client
 Summary:        YaST2 - Centralised System Authentication Configuration

--- a/src/lib/auth/authconf.rb
+++ b/src/lib/auth/authconf.rb
@@ -409,7 +409,7 @@ module Auth
                 end
             end
             # Write SSSD config file and correct its permission and ownerships
-            if File.exists?('/etc/sssd')
+            if File.exist?('/etc/sssd')
                 sssd_conf = File.new('/etc/sssd/sssd.conf', 'w')
                 sssd_conf.chmod(0600)
                 sssd_conf.chown(0, 0)


### PR DESCRIPTION
backport https://github.com/yast/yast-auth-client/pull/114 as SP6 is based on SP5 so missed this change.

Note: CI failing as I do not yet create testing SP6 containers