### PR TITLE
Skip white space only lines parsing krb5.conf

### DIFF
--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Sep 13 10:04:35 UTC 2023 - Samuel Cabrero <scabrero@suse.de>
+
+- Skip whitespace-only lines parsing krb5.conf; (bsc#1215297);
+- Remove duplicated when clause (dead code) in
+  src/lib/authui/ldapkrb/main_dialog.rb
+- 3.3.21
+
+-------------------------------------------------------------------
 Tue Mar 10 10:03:54 UTC 2020 - Samuel Cabrero <scabrero@suse.de>
 
 - yast auth-client and krb5.conf wrong domain_realm entry; (bsc#1122026)

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        3.3.20
+Version:        3.3.21
 Release:        0
 Url:            https://github.com/yast/yast-auth-client
 Summary:        YaST2 - Centralised System Authentication Configuration

--- a/src/lib/auth/krbparse.rb
+++ b/src/lib/auth/krbparse.rb
@@ -34,6 +34,11 @@ module Auth
                 if comment_match
                     next
                 end
+                # Skip empty lines
+                empty_match = /^\s+$/.match(line)
+                if empty_match
+                    next
+                end
                 # Remember include/includedir directives
                 include_match = /^(includedir|include|module)\s+(.+)$/.match(line)
                 if include_match

--- a/src/lib/authui/ldapkrb/main_dialog.rb
+++ b/src/lib/authui/ldapkrb/main_dialog.rb
@@ -166,8 +166,6 @@ module LdapKrb
                                 UI.ChangeWidget(Id(:nscd_enable), :Value, false)
                             end
                         end
-                    when :ldap_extended_opts
-                        LdapExtendedOptsDialog.new.run
 
                     # Kerberos tab events
                     when :krb_pam


### PR DESCRIPTION
## Problem

If krb5.conf contains any line having only white space characters the file is incorrectly parsed and domain join fails:

`The enrollment process failed. Command output: Failed to join domain: This machine is not currently joined to a domain.`

The resulting krb5.conf after the join attempt is also invalid:

```
 [libdefaults]
 ...
      =               <-- Invalid line
...

```

https://bugzilla.suse.com/show_bug.cgi?id=1215297

## Solution

Skip white space only lines


## Testing

- Tested manually

