### PR TITLE
Merge branch SLE-15-GA, skip white space only lines parsing krb5.conf

### DIFF
--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,16 @@
 -------------------------------------------------------------------
+Wed Sep 13 10:04:35 UTC 2023 - Samuel Cabrero <scabrero@suse.de>
+
+- Skip whitespace-only lines parsing krb5.conf; (bsc#1215297);
+- Remove duplicated when clause (dead code) in
+  src/lib/authui/ldapkrb/main_dialog.rb
+- Default bind_policy to 'soft' if not present in the config
+  (bsc#1162025).
+- Bug 1085084 yast2 client-auth tries to install nss_ldap and pam_ldap
+  All pam_ldap and nss_ldap stuff was removed
+- 4.1.4
+
+-------------------------------------------------------------------
 Fri Nov  8 12:32:21 UTC 2019 - Samuel Cabrero <scabrero@suse.de>
 
 - Add missing domain setting 'ignore_group_members'; (bsc#1153547);

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        4.1.3
+Version:        4.1.4
 Release:        0
 Url:            https://github.com/yast/yast-auth-client
 Summary:        YaST2 - Centralised System Authentication Configuration

--- a/src/lib/auth/authconf.rb
+++ b/src/lib/auth/authconf.rb
@@ -34,7 +34,7 @@ module Auth
         include Yast::Logger
         include Yast::UIShortcuts
 
-        attr_accessor(:krb_conf, :krb_pam, :ldap_conf, :ldap_pam, :ldap_nss, :sssd_conf, :sssd_pam, :sssd_nss, :sssd_enabled)
+        attr_accessor(:krb_conf, :krb_pam, :sssd_conf, :sssd_pam, :sssd_nss, :sssd_enabled)
         attr_accessor(:autofs_enabled, :nscd_enabled, :mkhomedir_pam)
         attr_accessor(:ad_domain, :ad_user, :ad_ou, :ad_pass, :ad_overwrite_smb_conf, :ad_update_dns, :autoyast_editor_mode, :autoyast_modified)
 
@@ -43,10 +43,6 @@ module Auth
             # Kerberos configuration
             @krb_conf = {'include' => [], 'libdefaults' => {}, 'realms' => {}, 'domain_realm' => {}, 'logging' => {}}
             @krb_pam = false
-            # LDAP configuration (/etc/ldap.conf)
-            @ldap_conf = {}
-            @ldap_pam = false
-            @ldap_nss = []
             # SSSD configuration (/etc/sssd/sssd.conf)
             @sssd_conf = {}
             @sssd_pam = false
@@ -165,11 +161,11 @@ module Auth
         end
 
         # Adjust PAM authentication setting lines to make sure that among the enabled mechanisms, any of
-        # unix/krb/ldap/sss can fullfill authentication attempt.
+        # unix/krb/sss can fullfill authentication attempt.
         # Be extra careful with making changes.
         # Return replacement lines after adjustments.
         def pam_fix_auth(original_lines)
-            sufficient_auth = ['pam_unix.so', 'pam_unix2.so', 'pam_sss.so', 'pam_ldap.so', 'pam_krb5.so']
+            sufficient_auth = ['pam_unix.so', 'pam_unix2.so', 'pam_sss.so', 'pam_krb5.so']
             ret = []
             original_lines.each { |line|
                 line.strip!
@@ -224,7 +220,7 @@ module Auth
         end
 
         # Adjust PAM settings to make sure:
-        # - Any of enabled unix/krb/ldap/sss mechanisms can fullfill user authentication.
+        # - Any of enabled unix/krb//sss mechanisms can fullfill user authentication.
         # - Local accounts are sufficient to be accounts.
         # Be extra careful with making changes.
         def fix_pam
@@ -434,118 +430,6 @@ module Auth
                 service_enable_start('sssd')
             else
                 service_disable_stop('sssd')
-            end
-        end
-
-        # Load LDAP configuration.
-        def ldap_read
-            @ldap_conf = {}
-            # Destruct ldap.conf file
-            Yast::SCR.UnmountAgent(Yast::Path.new('.etc.ldap_conf'))
-            Yast::SCR.Read(Yast::Path.new('.etc.ldap_conf.all')).fetch('value', []).each { |entry|
-                if entry['kind'] != 'value'
-                    skip
-                end
-                entry_name = entry['name'].strip
-                entry_value = entry['value'].strip
-                # Store values from duplicate keys in the original order
-                existing_value = @ldap_conf[entry_name]
-                if existing_value && existing_value.kind_of?(::String)
-                    @ldap_conf[entry_name] = [existing_value, entry_value]
-                elsif existing_value && existing_value.kind_of?(::Array)
-                    @ldap_conf[entry_name] = existing_value + [entry_value]
-                else
-                    @ldap_conf[entry_name] = entry_value
-                end
-            }
-            # Read PAM/NSS
-            @ldap_pam = Yast::Pam.Enabled('ldap')
-            @ldap_nss = []
-            LDAP_CAPABLE_NSS_DBS.each { |name|
-                if Yast::Nsswitch.ReadDb(name).any? { |db| db == 'ldap' }
-                    @ldap_nss += [name]
-                end
-            }
-        end
-
-        # Return LDAP configuration.
-        def ldap_export
-            return {'conf' => @ldap_conf, 'pam' => @ldap_pam, 'nss' => @ldap_nss}
-        end
-
-        # Set configuration for LDAP from exported objects.
-        def ldap_import(exported_conf)
-            @ldap_conf = exported_conf['conf']
-            @ldap_conf = {} if @ldap_conf.nil?
-            @ldap_pam = exported_conf['pam']
-            @ldap_pam = false if @ldap_pam.nil?
-            @ldap_nss = exported_conf['nss']
-            @ldap_nss = [] if @ldap_nss.nil?
-        end
-
-        # Generate ldap.conf content from the current configuration.
-        def ldap_make_conf
-            content = ''
-            @ldap_conf.each { |key, value|
-                if value.kind_of?(Array)
-                    value.each { |v|
-                        if v.to_s != ''
-                            content += "#{key} #{v}\n"
-                        end
-                    }
-                elsif value.to_s != ''
-                    content += "#{key} #{value}\n"
-                end
-            }
-            return content
-        end
-
-        # Immediately apply LDAP configuration, including PAM/NSS configuration.
-        def ldap_apply
-            if @autoyast_editor_mode
-                return
-            end
-            # Calculate package requirements
-            pkgs = []
-            if @ldap_pam
-                pkgs += ['pam_ldap']
-            end
-            if @ldap_nss
-                pkgs += ['nss_ldap']
-                if @ldap_nss.include?('automount')
-                    pkgs += ['openldap2-client'] # provides /etc/openldap/ldap.conf
-                end
-            end
-            pkgs.delete_if { |name| Yast::Package.Installed(name) }
-            if pkgs.any?
-                if !Yast::Package.DoInstall(pkgs)
-                    Yast::Report.Error(_('Failed to install software packages required for LDAP.'))
-                end
-            end
-            # Write LDAP config file and correct its permission and ownerships
-            ldap_conf = File.new('/etc/ldap.conf', 'w')
-            ldap_conf.chmod(0644)
-            ldap_conf.chown(0, 0)
-            ldap_conf.write(ldap_make_conf)
-            ldap_conf.close
-            # If automount is enabled, overwrite openldap's ldap.conf as well.
-            if @ldap_nss.include?('automount')
-                ldap_conf = File.new('/etc/openldap/ldap.conf', 'w')
-                ldap_conf.chmod(0644)
-                ldap_conf.chown(0, 0)
-                ldap_conf.write(ldap_make_conf)
-                ldap_conf.close
-            end
-            # Save PAM/NSS/daemon status
-            if @ldap_pam
-                Yast::Pam.Add('ldap')
-            else
-                Yast::Pam.Remove('ldap')
-            end
-            fix_pam
-            LDAP_CAPABLE_NSS_DBS.each { |db| nss_disable_module(db, 'ldap') }
-            if @ldap_nss.any?
-                @ldap_nss.each { |db| nss_enable_module(db, 'ldap') }
             end
         end
 
@@ -833,7 +717,7 @@ module Auth
             end
             # Install required packages
             pkgs = []
-            if @autofs_enabled || @sssd_nss.include?('automount') || @ldap_nss.include?('automount')
+            if @autofs_enabled || @sssd_nss.include?('automount')
                 pkgs += ['autofs']
             end
             if @nscd_enabled
@@ -853,7 +737,7 @@ module Auth
             end
             fix_pam
             # Start/stop daemons
-            if @autofs_enabled || @sssd_nss.include?('automount') || @ldap_nss.include?('automount')
+            if @autofs_enabled || @sssd_nss.include?('automount')
                 service_enable_start('autofs')
             else
                 service_disable_stop('autofs')
@@ -1020,7 +904,6 @@ module Auth
         def read_all
             clear
             krb_read
-            ldap_read
             aux_read
             sssd_read
         end
@@ -1043,19 +926,10 @@ module Auth
                     end
                 }
             end
-            if @ldap_pam
-                pkgs += ['pam_ldap']
-            end
             if @krb_pam
                 pkgs += ['pam_krb5', 'krb5', 'krb5-client']
             end
-            if @ldap_nss
-                pkgs += ['nss_ldap']
-                if @ldap_nss.include?('automount')
-                    pkgs += ['openldap2-client'] # provides /etc/openldap/ldap.conf
-                end
-            end
-            if @autofs_enabled || @sssd_nss.include?('automount') || @ldap_nss.include?('automount')
+            if @autofs_enabled || @sssd_nss.include?('automount')
                 pkgs += ['autofs']
             end
             if @nscd_enabled
@@ -1071,7 +945,7 @@ module Auth
         def summary_text
             # Figure out how authentication works on this computer
             auth_doms_caption = ''
-            if !@sssd_enabled && @ldap_nss.empty? && !@ldap_pam && !@krb_pam
+            if !@sssd_enabled && !@krb_pam
                 # Local only
                 auth_doms_caption = _('Only use local authentication')
             elsif @sssd_enabled && (@sssd_pam || @sssd_nss.any?)
@@ -1081,14 +955,6 @@ module Auth
                     auth_doms_caption += ' ' + _('(daemon is inactive)')
                 end
             else
-                # LDAP and/or Kerberos is configured
-                if @ldap_nss.any? || @ldap_pam
-                    if @ldap_conf['base'].to_s == ''
-                        auth_doms_caption = _('LDAP is enabled but the setup is incomplete')
-                    else
-                        auth_doms_caption = _('via LDAP on %s') % [@ldap_conf['base']]
-                    end
-                end
                 if @krb_pam
                     if auth_doms_caption != ''
                         # 'and' as in "authenticate via LDAP and Kerberos"

--- a/src/lib/auth/krbparse.rb
+++ b/src/lib/auth/krbparse.rb
@@ -34,6 +34,11 @@ module Auth
                 if comment_match
                     next
                 end
+                # Skip empty lines
+                empty_match = /^\s+$/.match(line)
+                if empty_match
+                    next
+                end
                 # Remember include/includedir directives
                 include_match = /^(includedir|include|module)\s+(.+)$/.match(line)
                 if include_match

--- a/src/lib/authui/ldapkrb/main_dialog.rb
+++ b/src/lib/authui/ldapkrb/main_dialog.rb
@@ -166,8 +166,6 @@ module LdapKrb
                                 UI.ChangeWidget(Id(:nscd_enable), :Value, false)
                             end
                         end
-                    when :ldap_extended_opts
-                        LdapExtendedOptsDialog.new.run
 
                     # Kerberos tab events
                     when :krb_pam
@@ -306,6 +304,12 @@ module LdapKrb
             when :ldap_tls_method_starttls
                 AuthConfInst.ldap_conf['ssl'] = 'start_tls'
             end
+
+            # bsc#1162025: Default bind_policy to soft if not present.
+            if !AuthConfInst.ldap_conf.key?('bind_policy')
+              AuthConfInst.ldap_conf['bind_policy'] = 'soft'
+            end
+
             AuthConfInst.mkhomedir_pam = UI.QueryWidget(Id(:mkhomedir_enable), :Value)
         end
 

--- a/test/authconf_test.rb
+++ b/test/authconf_test.rb
@@ -112,53 +112,6 @@ krb5_realm = ABC.ZZZ
         end
     end
 
-    describe 'LDAP' do
-        it 'Read, lint, and export LDAP configuration' do
-            authconf.ldap_read
-            expect(authconf.ldap_export).to eq(
-                'conf'=>{
-                    'host'=>'127.0.0.1',
-                    'base'=>'dc=example,dc=com',
-                    'bind_policy'=>'soft',
-                    'pam_lookup_policy'=>'yes',
-                    'pam_password'=>'exop',
-                    'nss_initgroups_ignoreusers'=>'root,ldap',
-                    'nss_schema'=>'rfc2307bis',
-                    'nss_map_attribute'=>'uniqueMember member',
-                    'ssl'=>'start_tls'},
-                'pam'=>false,
-                'nss'=>[])
-        end
-        it 'Create LDAP configuration file' do
-            expect(authconf.ldap_make_conf).to eq('host 127.0.0.1
-base dc=example,dc=com
-bind_policy soft
-pam_lookup_policy yes
-pam_password exop
-nss_initgroups_ignoreusers root,ldap
-nss_schema rfc2307bis
-nss_map_attribute uniqueMember member
-ssl start_tls
-')
-        end
-        it 'Import and recreate the same configuration' do
-            conf = {'conf'=>{
-                    'host'=>'127.0.0.1',
-                    'base'=>'dc=example,dc=com',
-                    'bind_policy'=>'soft',
-                    'pam_lookup_policy'=>'yes',
-                    'pam_password'=>'exop',
-                    'nss_initgroups_ignoreusers'=>'root,ldap',
-                    'nss_schema'=>'rfc2307bis',
-                    'nss_map_attribute'=>'uniqueMember member',
-                    'ssl'=>'start_tls'},
-                'pam'=>true,
-                'nss'=>['passwd', 'group']}
-            authconf.ldap_import(conf)
-            expect(authconf.ldap_export).to eq(conf)
-        end
-    end
-
     describe 'Kerberos' do
         it 'Read, lint, and export Kerberos configuration' do
             # The first example is very simple
@@ -438,7 +391,6 @@ auth    optional        pam_gnome_keyring.so
 auth    sufficient      pam_unix.so     try_first_pass
 auth    sufficient      pam_krb5.so     use_first_pass
 auth    sufficient      pam_sss.so      use_first_pass
-auth    required        pam_ldap.so     use_first_pass
 ".split("\n"))).to eq [
                 "",
                 "# comment",
@@ -447,7 +399,6 @@ auth    required        pam_ldap.so     use_first_pass
                 "auth    sufficient    pam_unix.so    try_first_pass",
                 "auth    sufficient    pam_krb5.so    use_first_pass",
                 "auth    sufficient    pam_sss.so    use_first_pass",
-                "auth    sufficient    pam_ldap.so    use_first_pass",
                 "auth    required    pam_deny.so"
             ]
         end
@@ -460,7 +411,6 @@ auth    optional        pam_gnome_keyring.so
 auth    sufficient      pam_unix2.so     try_first_pass
 auth    sufficient      pam_krb5.so     use_first_pass
 auth    sufficient      pam_sss.so      use_first_pass
-auth    required        pam_ldap.so     use_first_pass
 ".split("\n"))).to eq [
                 "",
                 "# comment",
@@ -469,7 +419,6 @@ auth    required        pam_ldap.so     use_first_pass
                 "auth    sufficient    pam_unix2.so    try_first_pass",
                 "auth    sufficient    pam_krb5.so    use_first_pass",
                 "auth    sufficient    pam_sss.so    use_first_pass",
-                "auth    sufficient    pam_ldap.so    use_first_pass",
                 "auth    required    pam_deny.so"
             ]
         end
@@ -481,7 +430,6 @@ account requisite       pam_unix.so     try_first_pass
 account required        pam_krb5.so     use_first_pass
 account sufficient      pam_localuser.so
 account sufficient      pam_sss.so      use_first_pass
-account required        pam_ldap.so     use_first_pass
 ".split("\n"))).to eq [
                 "",
                 "# comment",
@@ -489,7 +437,6 @@ account required        pam_ldap.so     use_first_pass
                 "account    sufficient    pam_localuser.so",
                 "account required        pam_krb5.so     use_first_pass",
                 "account sufficient      pam_sss.so      use_first_pass",
-                "account required        pam_ldap.so     use_first_pass"
             ]
         end
 
@@ -500,7 +447,6 @@ account requisite       pam_unix2.so     try_first_pass
 account required        pam_krb5.so     use_first_pass
 account sufficient      pam_localuser.so
 account sufficient      pam_sss.so      use_first_pass
-account required        pam_ldap.so     use_first_pass
 ".split("\n"))).to eq [
                 "",
                 "# comment",
@@ -508,7 +454,6 @@ account required        pam_ldap.so     use_first_pass
                 "account    sufficient    pam_localuser.so",
                 "account required        pam_krb5.so     use_first_pass",
                 "account sufficient      pam_sss.so      use_first_pass",
-                "account required        pam_ldap.so     use_first_pass"
             ]
         end
     end


### PR DESCRIPTION
## Problem

If krb5.conf contains any line having only white space characters the file is incorrectly parsed and domain join fails:

`The enrollment process failed. Command output: Failed to join domain: This machine is not currently joined to a domain.`

The resulting krb5.conf after the join attempt is also invalid:

```
 [libdefaults]
 ...
      =               <-- Invalid line
...

```

https://bugzilla.suse.com/show_bug.cgi?id=1215297

## Solution

Skip white space only lines


## Testing

- Tested manually

