### PR TITLE
Fix joining with samba 4.21

### DIFF
--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 25 11:14:02 UTC 2024 - Samuel Cabrero <scabrero@suse.de>
+
+- Use new smb.conf parameter "sync machine password to keytab"
+- Skip whitespace-only lines when parsing krb5.conf
+- 5.0.1
+
+-------------------------------------------------------------------
 Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 
 - 5.0.0 (bsc#1185510)

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        5.0.0
+Version:        5.0.1
 Release:        0
 Url:            https://github.com/yast/yast-auth-client
 Summary:        YaST2 - Centralised System Authentication Configuration

--- a/src/lib/auth/krbparse.rb
+++ b/src/lib/auth/krbparse.rb
@@ -34,6 +34,8 @@ module Auth
                 if comment_match
                     next
                 end
+                # Skip empty lines
+                next if line.match?(/^\s+$/)
                 # Remember include/includedir directives
                 include_match = /^(includedir|include|module)\s+(.+)$/.match(line)
                 if include_match

--- a/test/authconf_test.rb
+++ b/test/authconf_test.rb
@@ -32,6 +32,20 @@ describe Auth::AuthConf do
     end
     authconf = Auth::AuthConfInst
 
+    describe 'Samba' do
+        it 'Detect samba version' do
+            expect(authconf.is_installed_version_newer_or_equal?("4.20.1", "4.21.0")).to eq(false)
+            expect(authconf.is_installed_version_newer_or_equal?("4.21.0", "4.20.1")).to eq(true)
+            expect(authconf.is_installed_version_newer_or_equal?("4.21.0", "4.21.0")).to eq(true)
+            expect(authconf.is_installed_version_newer_or_equal?("4.20.1", "4.21")).to eq(false)
+            expect(authconf.is_installed_version_newer_or_equal?("4.21.0", "4.20")).to eq(true)
+            expect(authconf.is_installed_version_newer_or_equal?("4.21.0", "4.21")).to eq(true)
+            expect(authconf.is_installed_version_newer_or_equal?("4.20", "4.21.0")).to eq(false)
+            expect(authconf.is_installed_version_newer_or_equal?("4.21", "4.20.1")).to eq(true)
+            expect(authconf.is_installed_version_newer_or_equal?("4.21", "4.20.0")).to eq(true)
+        end
+    end
+
     describe 'SSSD' do
         it 'Read, lint, and export SSSD configuration' do
             authconf.sssd_read


### PR DESCRIPTION
## Problem

Samba 4.21 changes the way the system keytab is created. To add the machine account name to the keytab it is necessary to set `sync machine password to keytab = /etc/krb5.keytab:account_name:sync_etypes:sync_kvno:machine_password` in /etc/smb.conf. 

## Solution

Detect the installed samba version and add the necessary parameter.


## Testing

Manually tested.