### PR TITLE
Add reference to last changelog entry

### DIFF
--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -2,6 +2,7 @@
 Wed Sep 25 11:14:02 UTC 2024 - Samuel Cabrero <scabrero@suse.de>
 
 - Use new smb.conf parameter "sync machine password to keytab"
+  (gh#yast/yast-auth-client#122).
 - Skip whitespace-only lines when parsing krb5.conf
 - 5.0.1
 


### PR DESCRIPTION
Auto submission for https://github.com/yast/yast-auth-client/pull/122 has [failed](https://github.com/yast/yast-auth-client/pull/122#issuecomment-2426182501) becasue missing reference in changelog,

> Stopping, missing new bugzilla or fate entry in the *.changes file.
>
> https://github.com/yast/yast-auth-client/actions/runs/11437603416/job/31817441511

This PR reference https://github.com/yast/yast-auth-client/pull/122 to fix the issue.