### PR TITLE
Add support of sssd Information Pipe

### DIFF
--- a/package/yast2-auth-client.changes
+++ b/package/yast2-auth-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep 30 10:14:48 UTC 2025 - Samuel Cabrero <scabrero@suse.de>
+
+- Add support of sssd Information Pipe (bsc#1246696)
+- 4.6.2
+
+-------------------------------------------------------------------
 Mon Mar  6 16:47:05 UTC 2023 - Martin Vidner <mvidner@suse.com>
 
 - Stop using File.exists? which no longer works in Ruby 3.2

--- a/package/yast2-auth-client.spec
+++ b/package/yast2-auth-client.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-auth-client
-Version:        4.6.1
+Version:        4.6.2
 Release:        0
 URL:            https://github.com/yast/yast-auth-client
 Summary:        YaST2 - Centralised System Authentication Configuration

--- a/src/lib/authui/sssd/main_dialog.rb
+++ b/src/lib/authui/sssd/main_dialog.rb
@@ -41,6 +41,7 @@ module SSSD
                 "pam" => _("Authentication"), "sudo" => _("Sudo"),
                 "autofs" => _("Auto-Mount"), "ssh" => _("SSH Public Keys"),
                 "pac" => _("Privilege Account Certificate (MS-PAC)"),
+                "ifp" => _("Information Pipe"),
             }
             # The reverse caption mapping
             @sect_caption_name = Hash[*@sect_name_caption.map { |name, caption| [caption, name] }.flatten]
@@ -83,6 +84,7 @@ module SSSD
                                         Left(CheckBox(Id(:nss_automount), Opt(:notify), _("Map Network Drives (automount)"), AuthConfInst.sssd_nss.include?('automount'))),
                                         Left(CheckBox(Id(:svc_ssh), Opt(:notify), _("SSH Public Keys"), AuthConfInst.sssd_conf['sssd']['services'].include?('ssh'))),
                                         Left(CheckBox(Id(:svc_pac), Opt(:notify), _("Privilege Account Certificate (MS-PAC)"), AuthConfInst.sssd_conf['sssd']['services'].include?('pac'))),
+                                        Left(CheckBox(Id(:svc_ifp), Opt(:notify), _("Information Pipe"), AuthConfInst.sssd_conf['sssd']['services'].include?('ifp'))),
                                     )
                                 ),
                                 VSpacing(0.2),
@@ -378,6 +380,16 @@ module SSSD
                             AuthConfInst.sssd_enable_svc('pac')
                         else
                             AuthConfInst.sssd_disable_svc('pac')
+                        end
+                        render_section_tree
+
+                    when :svc_ifp
+                        # enable information pipe
+                        enable = UI.QueryWidget(Id(:svc_ifp), :Value)
+                        if enable
+                            AuthConfInst.sssd_enable_svc('ifp')
+                        else
+                            AuthConfInst.sssd_disable_svc('ifp')
                         end
                         render_section_tree
 


### PR DESCRIPTION
When in /etc/sssd/sssd.conf the service "ifp" (InFormation Pipe) is enabled the yast auth-client module can not longer be started, as it does not know the option and parsing the configuration fails.

This patch, contributed by [paul.zirnik@suse.com](mailto:paul.zirnik@suse.com), adds support for ifp to fix (bsc#1246696).

Tested manually
